### PR TITLE
Update config so it can be cached

### DIFF
--- a/config/dynamic-sqs.php
+++ b/config/dynamic-sqs.php
@@ -12,10 +12,8 @@ return [
     | "map" array below.
     |
     */
-    'discoverer' => function (array $payload): ?string {
-        return $payload['handler'] ?? null;
-    },
-
+    'discoverer' => [\eDriving\DynamicSqs\Commands\DiscovererHandler::class, 'discover'],
+    
     /*
     |--------------------------------------------------------------------------
     | Job Map

--- a/src/Commands/DiscovererHandler.php
+++ b/src/Commands/DiscovererHandler.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace eDriving\DynamicSqs\Commands;
+
+class DiscovererHandler
+{
+    public static function discover(array $payload): ?string
+    {
+        return $payload['handler'] ?? null;
+    }
+}


### PR DESCRIPTION
Running `php artisan config:cache` currently throws an exception:  `Your configuration files are not serializable.`

The packages config has a Closure (anonymous function) which means it cannot be serialised and cannot be cached.

This Pull Request adds a Discoverer command class so we can cache the config.